### PR TITLE
Try the 'bootstrap-if-needed' strategy

### DIFF
--- a/TidepoolService.xcodeproj/project.pbxproj
+++ b/TidepoolService.xcodeproj/project.pbxproj
@@ -630,7 +630,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Bootstrapping Carthage dependencies...\"\nunset LLVM_TARGET_TRIPLE_SUFFIX\ntime /usr/local/bin/carthage bootstrap --project-directory \"${SRCROOT}\" --platform ios --cache-builds --verbose\n";
+			shellScript = "echo \"Bootstrapping Carthage dependencies...\"\nunset LLVM_TARGET_TRIPLE_SUFFIX\n\nif ! cmp -s Cartfile.Resolved Carthage/Cartfile.resolved; then\n    time /usr/local/bin/carthage bootstrap --project-directory \"$SRCROOT\" --platform ios --cache-builds --verbose\n    cp Cartfile.resolved Carthage\nelse\n    echo \"Carthage: not bootstrapping\"\nfi\n";
 		};
 		A9DAAD5F22E7E75C00E76C9F /* Copy Frameworks with Carthage */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This small modification to the `Cartfile` build script target only bootstraps if `Cartfile.resolved` changes.  This makes it so that build caching can be effective (especially in CI).