### PR TITLE
LOOP-1495: Pass in prescription to TherapySettingsViewModel

### DIFF
--- a/TidepoolServiceKit/Mocks/MockPrescription.swift
+++ b/TidepoolServiceKit/Mocks/MockPrescription.swift
@@ -32,7 +32,7 @@ public enum PumpType: String, Codable {
     case dash
 }
 
-public struct MockPrescription: Codable {
+public struct MockPrescription: Prescription, Codable {
     public let datePrescribed: Date // Date prescription was prescribed
     public let providerName: String // Name of clinician prescribing
     public let cgm: CGMType // CGM type (manufacturer & model)

--- a/TidepoolServiceKitUI/View Controllers/PrescriptionReviewUICoordinator.swift
+++ b/TidepoolServiceKitUI/View Controllers/PrescriptionReviewUICoordinator.swift
@@ -318,7 +318,8 @@ class PrescriptionReviewUICoordinator: UINavigationController, CompletionNotifyi
             syncPumpSchedule: { _, _ in
                 // Since pump isn't set up, this syncing shouldn't do anything
                 assertionFailure()
-        }
+            },
+            prescription: prescription
         ) { [weak self] _, _ in
             self?.stepFinished()
         }


### PR DESCRIPTION
This passes in the prescription object into `TherapySettingsViewModel` so that it displays appropriately.