### PR TITLE
LOOP-XXXX: Changes pumpSupportedIncrements and syncPumpSchedule to getters

### DIFF
--- a/TidepoolServiceKitUI/View Controllers/PrescriptionReviewUICoordinator.swift
+++ b/TidepoolServiceKitUI/View Controllers/PrescriptionReviewUICoordinator.swift
@@ -346,10 +346,12 @@ class PrescriptionReviewUICoordinator: UINavigationController, CompletionNotifyi
             mode: .acceptanceFlow,
             therapySettings: prescription.therapySettings,
             supportedInsulinModelSettings: supportedInsulinModelSettings,
-            pumpSupportedIncrements: pumpSupportedIncrements,
-            syncPumpSchedule: { _, _ in
-                // Since pump isn't set up, this syncing shouldn't do anything
-                assertionFailure()
+            pumpSupportedIncrements: { pumpSupportedIncrements },
+            syncPumpSchedule: {
+                { _, _ in
+                    // Since pump isn't set up, this syncing shouldn't do anything
+                    assertionFailure()
+                }
             },
             prescription: prescription,
             chartColors: chartColors


### PR DESCRIPTION
Instead of passing in `pumpSupportedIncrements` and `syncPumpSchedule` once upon creation of a `TherapySettingsViewModel`, pass in "getters" instead.

(Side note: this has been a common refrain for solving "refresh" problems...)

See also https://github.com/tidepool-org/LoopKit/pull/241 and https://github.com/tidepool-org/Loop/pull/253