### PR TITLE
[LOOP-3924] Update carb and glucose uploads to Tidepool Service to ensure consistent data

### DIFF
--- a/TidepoolService.xcodeproj/project.pbxproj
+++ b/TidepoolService.xcodeproj/project.pbxproj
@@ -36,12 +36,15 @@
 		A94AE4F2235A8B75005CA320 /* TidepoolServiceKitPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AE4F1235A8B75005CA320 /* TidepoolServiceKitPlugin.swift */; };
 		A94AE4F5235A8BAC005CA320 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AE4F4235A8BAC005CA320 /* OSLog.swift */; };
 		A9672B5926E82EBA0025B0CD /* StoredGlucoseSampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9672B5826E82EBA0025B0CD /* StoredGlucoseSampleTests.swift */; };
+		A9752A9D270B972D00E50750 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9752A9C270B972D00E50750 /* TimeInterval.swift */; };
 		A97651752421AA10002EB5D4 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AE4F4235A8BAC005CA320 /* OSLog.swift */; };
 		A97651762421AA11002EB5D4 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94AE4F4235A8BAC005CA320 /* OSLog.swift */; };
 		A97A60FB243818C900AD69A5 /* TDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97A60FA243818C900AD69A5 /* TDatum.swift */; };
+		A9A53E2F271508D80050C0B1 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A53E2E271508D80050C0B1 /* String.swift */; };
 		A9BF371D2418195C008D7F34 /* TidepoolKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9BF371C2418195C008D7F34 /* TidepoolKit.framework */; };
 		A9BF371F24181978008D7F34 /* TidepoolKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9BF371E24181977008D7F34 /* TidepoolKitUI.framework */; };
 		A9D1107C242289720091C620 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1107B242289720091C620 /* HKUnit.swift */; };
+		A9D58155272B266700AA5C18 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D58154272B266700AA5C18 /* Date.swift */; };
 		A9DAAD0822E7987800E76C9F /* TidepoolServiceKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9DAACFF22E7987800E76C9F /* TidepoolServiceKit.framework */; };
 		A9DAAD0F22E7987800E76C9F /* TidepoolServiceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A9DAAD0122E7987800E76C9F /* TidepoolServiceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9DAAD2422E7988900E76C9F /* TidepoolServiceKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9DAAD1B22E7988900E76C9F /* TidepoolServiceKitUI.framework */; };
@@ -62,6 +65,9 @@
 		A9DAAD6A22E7E81E00E76C9F /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9DAAD6922E7E81E00E76C9F /* LoopKitUI.framework */; };
 		A9DAAD6D22E7EA8F00E76C9F /* IdentifiableClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAAD6C22E7EA8F00E76C9F /* IdentifiableClass.swift */; };
 		A9DAAD6F22E7EA9700E76C9F /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAAD6E22E7EA9700E76C9F /* NibLoadable.swift */; };
+		A9E8C60D272C723400016E2E /* SyncCarbObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E8C60C272C723400016E2E /* SyncCarbObjectTests.swift */; };
+		A9E8C611272C76A500016E2E /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E8C610272C76A500016E2E /* TimeInterval.swift */; };
+		A9F9F319271A05B100D19374 /* IdentifiableHKDatum.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F9F318271A05B100D19374 /* IdentifiableHKDatum.swift */; };
 		E93BA06224A29C9C00C5D7E6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E93BA06124A29C9C00C5D7E6 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -116,12 +122,15 @@
 		A94AE4F1235A8B75005CA320 /* TidepoolServiceKitPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolServiceKitPlugin.swift; sourceTree = "<group>"; };
 		A94AE4F4235A8BAC005CA320 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		A9672B5826E82EBA0025B0CD /* StoredGlucoseSampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredGlucoseSampleTests.swift; sourceTree = "<group>"; };
+		A9752A9C270B972D00E50750 /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
 		A97A60FA243818C900AD69A5 /* TDatum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDatum.swift; sourceTree = "<group>"; };
 		A99222FA235A879600C11C04 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A99222FB235A87B100C11C04 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A9A53E2E271508D80050C0B1 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		A9BF371C2418195C008D7F34 /* TidepoolKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TidepoolKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9BF371E24181977008D7F34 /* TidepoolKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TidepoolKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9D1107B242289720091C620 /* HKUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKUnit.swift; sourceTree = "<group>"; };
+		A9D58154272B266700AA5C18 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		A9DAACFF22E7987800E76C9F /* TidepoolServiceKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TidepoolServiceKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9DAAD0122E7987800E76C9F /* TidepoolServiceKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TidepoolServiceKit.h; sourceTree = "<group>"; };
 		A9DAAD0222E7987800E76C9F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -162,6 +171,9 @@
 		A9DAAD6922E7E81E00E76C9F /* LoopKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LoopKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9DAAD6C22E7EA8F00E76C9F /* IdentifiableClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableClass.swift; sourceTree = "<group>"; };
 		A9DAAD6E22E7EA9700E76C9F /* NibLoadable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NibLoadable.swift; sourceTree = "<group>"; };
+		A9E8C60C272C723400016E2E /* SyncCarbObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCarbObjectTests.swift; sourceTree = "<group>"; };
+		A9E8C610272C76A500016E2E /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
+		A9F9F318271A05B100D19374 /* IdentifiableHKDatum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableHKDatum.swift; sourceTree = "<group>"; };
 		E93BA06124A29C9C00C5D7E6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -224,10 +236,13 @@
 			isa = PBXGroup;
 			children = (
 				A913B37C24200C97000805C4 /* Bundle.swift */,
+				A9D58154272B266700AA5C18 /* Date.swift */,
 				A9D1107B242289720091C620 /* HKUnit.swift */,
 				A9309CA62435987000E02268 /* SyncCarbObject.swift */,
 				A9309CAE2436C52900E02268 /* StoredGlucoseSample.swift */,
+				A9A53E2E271508D80050C0B1 /* String.swift */,
 				A97A60FA243818C900AD69A5 /* TDatum.swift */,
+				A9752A9C270B972D00E50750 /* TimeInterval.swift */,
 				A9309CA2243563CD00E02268 /* TOrigin.swift */,
 			);
 			path = Extensions;
@@ -255,6 +270,7 @@
 			isa = PBXGroup;
 			children = (
 				A9672B5826E82EBA0025B0CD /* StoredGlucoseSampleTests.swift */,
+				A9E8C60C272C723400016E2E /* SyncCarbObjectTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -299,6 +315,7 @@
 			children = (
 				A9DAAD0122E7987800E76C9F /* TidepoolServiceKit.h */,
 				A9DAAD0222E7987800E76C9F /* Info.plist */,
+				A9F9F318271A05B100D19374 /* IdentifiableHKDatum.swift */,
 				A9DAAD3522E7CAC100E76C9F /* TidepoolService.swift */,
 				A913B37B24200C86000805C4 /* Extensions */,
 				A9DAAD4122E7DF9B00E76C9F /* Localizable.strings */,
@@ -309,9 +326,10 @@
 		A9DAAD0B22E7987800E76C9F /* TidepoolServiceKitTests */ = {
 			isa = PBXGroup;
 			children = (
-				A9672B5626E82E6E0025B0CD /* Extensions */,
 				A9DAAD0E22E7987800E76C9F /* Info.plist */,
 				1D70C41326F28CC900C62570 /* URLProtocolMock.swift */,
+				A9672B5626E82E6E0025B0CD /* Extensions */,
+				A9E8C60E272C768300016E2E /* Private */,
 			);
 			path = TidepoolServiceKitTests;
 			sourceTree = "<group>";
@@ -353,6 +371,22 @@
 				A9DAAD5A22E7E6BE00E76C9F /* LoopKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A9E8C60E272C768300016E2E /* Private */ = {
+			isa = PBXGroup;
+			children = (
+				A9E8C60F272C768C00016E2E /* Extensions */,
+			);
+			path = Private;
+			sourceTree = "<group>";
+		};
+		A9E8C60F272C768C00016E2E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A9E8C610272C76A500016E2E /* TimeInterval.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -689,13 +723,17 @@
 			files = (
 				A9309CAF2436C52900E02268 /* StoredGlucoseSample.swift in Sources */,
 				A9D1107C242289720091C620 /* HKUnit.swift in Sources */,
+				A9752A9D270B972D00E50750 /* TimeInterval.swift in Sources */,
 				A9309CA72435987000E02268 /* SyncCarbObject.swift in Sources */,
+				A9A53E2F271508D80050C0B1 /* String.swift in Sources */,
 				A97A60FB243818C900AD69A5 /* TDatum.swift in Sources */,
 				A9DAAD3322E7CA1A00E76C9F /* LocalizedString.swift in Sources */,
 				A913B37D24200C97000805C4 /* Bundle.swift in Sources */,
+				A9F9F319271A05B100D19374 /* IdentifiableHKDatum.swift in Sources */,
 				A9309CA3243563CD00E02268 /* TOrigin.swift in Sources */,
 				A97651752421AA10002EB5D4 /* OSLog.swift in Sources */,
 				A9DAAD3622E7CAC100E76C9F /* TidepoolService.swift in Sources */,
+				A9D58155272B266700AA5C18 /* Date.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -703,6 +741,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9E8C611272C76A500016E2E /* TimeInterval.swift in Sources */,
+				A9E8C60D272C723400016E2E /* SyncCarbObjectTests.swift in Sources */,
 				1D70C41426F28CC900C62570 /* URLProtocolMock.swift in Sources */,
 				A9672B5926E82EBA0025B0CD /* StoredGlucoseSampleTests.swift in Sources */,
 			);

--- a/TidepoolServiceKit/Extensions/Date.swift
+++ b/TidepoolServiceKit/Extensions/Date.swift
@@ -1,0 +1,28 @@
+//
+//  Date.swift
+//  TidepoolServiceKit
+//
+//  Created by Darin Krauss on 11/5/19.
+//  Copyright © 2019 Tidepool Project. All rights reserved.
+//
+
+import Foundation
+
+extension Date {
+    var timeString: String {
+        return Date.timeFormatter.string(from: self.roundedToTimeInterval(.millisecond))
+    }
+
+    private static let timeFormatter: ISO8601DateFormatter = {
+        var timeFormatter = ISO8601DateFormatter()
+        timeFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return timeFormatter
+    }()
+
+    private func roundedToTimeInterval(_ interval: TimeInterval) -> Date {
+        guard interval != 0 else {
+            return self
+        }
+        return Date(timeIntervalSinceReferenceDate: round(self.timeIntervalSinceReferenceDate / interval) * interval)
+    }
+}

--- a/TidepoolServiceKit/Extensions/String.swift
+++ b/TidepoolServiceKit/Extensions/String.swift
@@ -14,6 +14,6 @@ extension String {
             return nil
         }
         let hash = Insecure.MD5.hash(data: data)
-        return hash.map { String(format: "%02hhx", $0) }.joined().uppercased()
+        return hash.map { String(format: "%02hhx", $0) }.joined()
     }
 }

--- a/TidepoolServiceKit/Extensions/String.swift
+++ b/TidepoolServiceKit/Extensions/String.swift
@@ -1,0 +1,19 @@
+//
+//  String.swift
+//  TidepoolServiceKit
+//
+//  Created by Darin Krauss on 10/11/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import CryptoKit
+
+extension String {
+    var md5hash: String? {
+        guard let data = data(using: .utf8) else {
+            return nil
+        }
+        let hash = Insecure.MD5.hash(data: data)
+        return hash.map { String(format: "%02hhx", $0) }.joined().uppercased()
+    }
+}

--- a/TidepoolServiceKit/Extensions/SyncCarbObject.swift
+++ b/TidepoolServiceKit/Extensions/SyncCarbObject.swift
@@ -6,16 +6,38 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-import CryptoKit
 import LoopKit
 import TidepoolKit
 
-extension SyncCarbObject {
-    var datum: TDatum? {
-        guard let origin = datumOrigin else {
+/*
+ SyncCarbObject
+ 
+ Properties:
+ - absorptionTime          TimeInterval?       .nutrition.estimatedAbsorptionDuration
+ - createdByCurrentApp     Bool                (N/A - implied by SyncCarbObject.provenanceIdentifier)
+ - foodType                String?             .name
+ - grams                   Double              .nutrition.carbohydrate.net
+ - startDate               Date                .time
+ - uuid                    UUID?               .id, .origin.id, .payload["uuid"]
+ - provenanceIdentifier    String              .id, .origin.id, .origin.name (if not this app)
+ - syncIdentifier          String?             .id, .origin.id, .payload["syncIdentifier"]
+ - syncVersion             Int?                .payload["syncVersion"]
+ - userCreatedDate         Date?               .payload["userCreatedDate"]
+ - userUpdatedDate         Date?               .payload["userUpdatedDate"]
+ - userDeletedDate         Date?               .payload["userDeletedDate"]
+ - operation               Operation           (N/A - implied by RemoteDataService.uploadCarbData API)
+ - addedDate               Date?               .payload["addedDate"]
+ - supercededDate          Date?               .payload["supercededDate"]
+ */
+
+// TODO: Consider adding syncVersion to new update backend API (or just keep in payload)
+
+extension SyncCarbObject: IdentifiableHKDatum {
+    func datum(for userId: String) -> TFoodDatum? {
+        guard let id = datumId(for: userId) else {
             return nil
         }
-        return TFoodDatum(time: datumTime, name: datumName, nutrition: datumNutrition).adornWith(origin: origin)
+        return TFoodDatum(time: datumTime, name: datumName, nutrition: datumNutrition).adornWith(id: id, payload: datumPayload, origin: datumOrigin)
     }
 
     private var datumTime: Date { startDate }
@@ -27,70 +49,28 @@ extension SyncCarbObject {
     }
 
     private var datumCarbohydrate: TFoodDatum.Nutrition.Carbohydrate {
-        return TFoodDatum.Nutrition.Carbohydrate(net: grams)
+        return TFoodDatum.Nutrition.Carbohydrate(net: quantity.doubleValue(for: .gram()), units: .grams)
     }
 
-    private var datumOrigin: TOrigin? {
-        guard let resolvedSyncIdentifier = resolvedSyncIdentifier else {
-            return nil
-        }
-        if let provenanceIdentifier = provenanceIdentifier, !provenanceIdentifier.isEmpty, provenanceIdentifier != Bundle.main.bundleIdentifier {
-            return TOrigin(id: resolvedSyncIdentifier, name: provenanceIdentifier, type: .application)
-        }
-        return TOrigin(id: resolvedSyncIdentifier)
+    private var datumPayload: TDictionary? {
+        var dictionary = TDictionary()
+        dictionary["uuid"] = uuid?.uuidString
+        dictionary["syncIdentifier"] = syncIdentifier
+        dictionary["syncVersion"] = syncVersion
+        dictionary["userCreatedDate"] = userCreatedDate?.timeString
+        dictionary["userUpdatedDate"] = userUpdatedDate?.timeString
+        dictionary["userDeletedDate"] = userDeletedDate?.timeString
+        dictionary["addedDate"] = addedDate?.timeString
+        dictionary["supercededDate"] = supercededDate?.timeString
+        return !dictionary.isEmpty ? dictionary : nil
     }
 }
 
 extension SyncCarbObject {
     var selector: TDatum.Selector? {
-        guard let resolvedSyncIdentifier = resolvedSyncIdentifier else {
+        guard let resolvedIdentifier = resolvedIdentifier else {
             return nil
         }
-        return TDatum.Selector(origin: TDatum.Selector.Origin(id: resolvedSyncIdentifier))
-    }
-}
-
-fileprivate extension SyncCarbObject {
-    var resolvedSyncIdentifier: String? {
-        var resolvedString: String?
-
-        // The Tidepool backend requires a unique identifier for each datum that does not change from creation
-        // through updates to deletion. Since carb objects do not inherently have such a unique identifier,
-        // we can generate one based upon the HealthKit provenance identifier (the unique source identifier of
-        // the carb, namely the bundle identifier) plus the HealthKit sync identifier.
-        //
-        // However, while all carbs created within Loop are guaranteed to have a HealthKit sync identifier, this
-        // is not true for carbs created outside of Loop. In this case, we fall back to using the HealthKit UUID.
-        // This works because any HealthKit objects without a sync identifier CANNOT be updated, by definition,
-        // (only created and deleted) and the UUID is constant for this use case.
-        if let provenanceIdentifier = provenanceIdentifier {
-            if let syncIdentifier = syncIdentifier {
-                resolvedString = "provenanceIdentifier:\(provenanceIdentifier):syncIdentifier:\(syncIdentifier)"
-            } else if let uuid = uuid {
-                resolvedString = "provenanceIdentifier:\(provenanceIdentifier):uuid:\(uuid)"
-            }
-        } else {
-
-            // DEPRECATED: Backwards compatibility (DIY)
-            // For previously existing carbs created outside of Loop we do not have a provenance identifier and
-            // we cannot rely on the sync identifier (since it is scoped by the provenance identifier). Therefore,
-            // just fallback to use the UUID.
-            if let uuid = uuid {
-                resolvedString = "uuid:\(uuid)"
-            }
-        }
-
-        // Finally, assuming we have a valid string, MD5 hash the string to yield a nice identifier
-        return resolvedString?.md5hash
-    }
-}
-
-fileprivate extension String {
-    var md5hash: String? {
-        guard let data = data(using: .utf8) else {
-            return nil
-        }
-        let hash = Insecure.MD5.hash(data: data)
-        return hash.map { String(format: "%02hhx", $0) }.joined()
+        return TDatum.Selector(origin: TDatum.Selector.Origin(id: resolvedIdentifier))
     }
 }

--- a/TidepoolServiceKit/Extensions/TDatum.swift
+++ b/TidepoolServiceKit/Extensions/TDatum.swift
@@ -9,9 +9,26 @@
 import TidepoolKit
 
 extension TDatum {
-    func adornWith(annotations: [TDictionary]? = nil, origin: TOrigin? = nil) -> TDatum {
+    func adornWith(id: String? = nil,
+                   deviceId: String? = nil,
+                   annotations: [TDictionary]? = nil,
+                   associations: [TAssociation]? = nil,
+                   payload: TDictionary? = nil,
+                   origin: TOrigin? = nil) -> Self {
+        if let id = id {
+            self.id = !id.isEmpty ? id : nil
+        }
+        if let deviceId = deviceId {
+            self.deviceId = !deviceId.isEmpty ? deviceId : nil
+        }
         if let annotations = annotations {
-            self.annotations = annotations
+            self.annotations = annotations.contains(where: { !$0.isEmpty }) ? annotations : nil
+        }
+        if let associations = associations {
+            self.associations = !associations.isEmpty ? associations : nil
+        }
+        if let payload = payload {
+            self.payload = !payload.isEmpty ? payload : nil
         }
         if let origin = origin {
             self.origin = origin

--- a/TidepoolServiceKit/Extensions/TimeInterval.swift
+++ b/TidepoolServiceKit/Extensions/TimeInterval.swift
@@ -1,0 +1,117 @@
+//
+//  TimeInterval.swift
+//  TidepoolServiceKit
+//
+//  Created by Darin Krauss on 10/4/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+extension TimeInterval {
+    static let day = days(1)
+    static let hour = hours(1)
+    static let minute = minutes(1)
+    static let second = seconds(1)
+    static let millisecond = milliseconds(1)
+
+    static func days(_ days: Double) -> Self {
+        return Self(days: days)
+    }
+
+    static func days(_ days: Int) -> Self {
+        return Self(days: days)
+    }
+
+    static func hours(_ hours: Double) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func hours(_ hours: Int) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func minutes(_ minutes: Double) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func minutes(_ minutes: Int) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func seconds(_ seconds: Double) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func seconds(_ seconds: Int) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func milliseconds(_ milliseconds: Double) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    static func milliseconds(_ milliseconds: Int) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    init(days: Double) {
+        self.init(hours: days * 24)
+    }
+
+    init(days: Int) {
+        self.init(hours: days * 24)
+    }
+
+    init(hours: Double) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(hours: Int) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(minutes: Double) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(minutes: Int) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(seconds: Double) {
+        self.init(seconds)
+    }
+
+    init(seconds: Int) {
+        self.init(seconds)
+    }
+
+    init(milliseconds: Double) {
+        self.init(seconds: milliseconds / 1000)
+    }
+
+    init(milliseconds: Int) {
+        self.init(seconds: Double(milliseconds) / 1000)
+    }
+
+    var days: Double {
+        return hours / 24
+    }
+
+    var hours: Double {
+        return minutes / 60
+    }
+
+    var minutes: Double {
+        return seconds / 60
+    }
+
+    var seconds: Double {
+        return self
+    }
+
+    var milliseconds: Double {
+        return seconds * 1000
+    }
+}

--- a/TidepoolServiceKit/IdentifiableHKDatum.swift
+++ b/TidepoolServiceKit/IdentifiableHKDatum.swift
@@ -1,0 +1,94 @@
+//
+//  IdentifiableHKDatum.swift
+//  TidepoolServiceKit
+//
+//  Created by Darin Krauss on 10/15/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import TidepoolKit
+
+protocol TypedDatum {
+    static var resolvedType: String { get }
+}
+
+protocol IdentifiableHKDatum {
+    var provenanceIdentifier: String { get }
+    var syncIdentifier: String? { get }
+    var uuid: UUID? { get }
+}
+
+extension IdentifiableHKDatum {
+    func datumId(for userId: String) -> String? {
+        return datumId(for: userId, resolvedIdentifier: resolvedIdentifier)
+    }
+
+    func datumId<T: TypedDatum>(for userId: String, type: T.Type) -> String? {
+        return datumId(for: userId, resolvedIdentifier: resolvedIdentifier(for: type))
+    }
+
+    private func datumId(for userId: String, resolvedIdentifier: String?) -> String? {
+        guard let resolvedIdentifier = resolvedIdentifier else {
+            return nil
+        }
+        return "\(userId):\(resolvedIdentifier)".md5hash
+    }
+
+    var datumOrigin: TOrigin? {
+        return datumOrigin(for: resolvedIdentifier)
+    }
+
+    func datumOrigin<T: TypedDatum>(for type: T.Type) -> TOrigin? {
+        return datumOrigin(for: resolvedIdentifier(for: type))
+    }
+
+    private func datumOrigin(for resolvedIdentifier: String?) -> TOrigin? {
+        guard let resolvedIdentifier = resolvedIdentifier else {
+            return nil
+        }
+        if !provenanceIdentifier.isEmpty, provenanceIdentifier != Bundle.main.bundleIdentifier {
+            return TOrigin(id: resolvedIdentifier, name: provenanceIdentifier, type: .application)
+        }
+        return TOrigin(id: resolvedIdentifier)
+    }
+
+    var resolvedIdentifier: String? {
+        var resolvedIdentifier: String?
+
+        // The Tidepool backend requires a unique identifier for each datum that does not change from creation
+        // through updates to deletion. Since some objects do not inherently have such a unique identifier,
+        // we can generate one based upon the HealthKit provenance identifier (the unique source identifier of
+        // the object, namely the bundle identifier) plus the HealthKit sync identifier.
+        //
+        // However, while all objects created within Loop are guaranteed to have a HealthKit sync identifier, this
+        // is not true for objects created outside of Loop. In this case, we fall back to using the HealthKit UUID.
+        // This works because any HealthKit objects without a sync identifier CANNOT be updated, by definition,
+        // (only created and deleted) and the UUID is constant for this use case.
+        if !provenanceIdentifier.isEmpty {
+            if let syncIdentifier = syncIdentifier, !syncIdentifier.isEmpty {
+                resolvedIdentifier = "provenanceIdentifier:\(provenanceIdentifier):syncIdentifier:\(syncIdentifier)"
+            } else if let uuid = uuid {
+                resolvedIdentifier = "provenanceIdentifier:\(provenanceIdentifier):uuid:\(uuid.uuidString)"
+            }
+        } else {
+
+            // DEPRECATED: Backwards compatibility (DIY)
+            // For previously existing objects created outside of Loop we do not have a provenance identifier and
+            // we cannot rely on the sync identifier (since it is scoped by the provenance identifier). Therefore,
+            // just fallback to use the UUID.
+            if let uuid = uuid {
+                resolvedIdentifier = "uuid:\(uuid.uuidString)"
+            }
+        }
+
+        // Finally, assuming we have a valid string, MD5 hash the string to yield a nice identifier
+        return resolvedIdentifier?.md5hash
+    }
+
+    func resolvedIdentifier<T: TypedDatum>(for type: T.Type) -> String? {
+        guard let resolvedIdentifier = resolvedIdentifier else {
+            return nil
+        }
+        return "\(resolvedIdentifier):\(type.resolvedType)"
+    }
+}

--- a/TidepoolServiceKitTests/Extensions/StoredGlucoseSampleTests.swift
+++ b/TidepoolServiceKitTests/Extensions/StoredGlucoseSampleTests.swift
@@ -30,9 +30,9 @@ class StoredGlucoseSampleTests: XCTestCase {
         let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
         XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
 {
-  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "id" : "4cf2a0566365e60b3f9618f39de149b8",
   "origin" : {
-    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "id" : "e71808a78873168e1c21dcd6636290ba",
     "name" : "135CDABE-9343-7242-4233-1020384789AE",
     "type" : "application"
   },
@@ -68,9 +68,9 @@ class StoredGlucoseSampleTests: XCTestCase {
         let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
         XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
 {
-  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "id" : "4cf2a0566365e60b3f9618f39de149b8",
   "origin" : {
-    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "id" : "e71808a78873168e1c21dcd6636290ba",
     "name" : "135CDABE-9343-7242-4233-1020384789AE",
     "type" : "application"
   },
@@ -106,9 +106,9 @@ class StoredGlucoseSampleTests: XCTestCase {
         let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
         XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
 {
-  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "id" : "4cf2a0566365e60b3f9618f39de149b8",
   "origin" : {
-    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "id" : "e71808a78873168e1c21dcd6636290ba",
     "name" : "135CDABE-9343-7242-4233-1020384789AE",
     "type" : "application"
   },
@@ -152,9 +152,9 @@ class StoredGlucoseSampleTests: XCTestCase {
       "value" : "low"
     }
   ],
-  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "id" : "4cf2a0566365e60b3f9618f39de149b8",
   "origin" : {
-    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "id" : "e71808a78873168e1c21dcd6636290ba",
     "name" : "135CDABE-9343-7242-4233-1020384789AE",
     "type" : "application"
   },
@@ -198,9 +198,9 @@ class StoredGlucoseSampleTests: XCTestCase {
       "value" : "high"
     }
   ],
-  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "id" : "4cf2a0566365e60b3f9618f39de149b8",
   "origin" : {
-    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "id" : "e71808a78873168e1c21dcd6636290ba",
     "name" : "135CDABE-9343-7242-4233-1020384789AE",
     "type" : "application"
   },

--- a/TidepoolServiceKitTests/Extensions/StoredGlucoseSampleTests.swift
+++ b/TidepoolServiceKitTests/Extensions/StoredGlucoseSampleTests.swift
@@ -13,12 +13,12 @@ import LoopKit
 @testable import TidepoolServiceKit
 
 class StoredGlucoseSampleTests: XCTestCase {
-    func testCalibrationDeviceEvent() {
-        let sample = StoredGlucoseSample(uuid: UUID(),
-                                         provenanceIdentifier: UUID().uuidString,
-                                         syncIdentifier: UUID().uuidString,
+    func testDatumCalibrationDeviceEvent() {
+        let sample = StoredGlucoseSample(uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                         provenanceIdentifier: "135CDABE-9343-7242-4233-1020384789AE",
+                                         syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
                                          syncVersion: 1,
-                                         startDate: Date(),
+                                         startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
                                          quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 123),
                                          condition: nil,
                                          trend: nil,
@@ -27,25 +27,36 @@ class StoredGlucoseSampleTests: XCTestCase {
                                          wasUserEntered: false,
                                          device: nil,
                                          healthKitEligibleDate: nil)
-        let datum = sample.datum as? TidepoolKit.TCalibrationDeviceEventDatum
-        XCTAssertNotNil(datum)
-        XCTAssertEqual(datum?.time, sample.startDate)
-        XCTAssertEqual(datum?.value, 123)
-        XCTAssertEqual(datum?.units, .milligramsPerDeciliter)
-        XCTAssertNil(datum?.annotations)
-        XCTAssertNotNil(datum?.origin)
-        XCTAssertEqual(datum?.origin?.id, sample.syncIdentifier)
-        XCTAssertEqual(datum?.origin?.name, sample.provenanceIdentifier)
-        XCTAssertNil(datum?.origin?.version)
-        XCTAssertEqual(datum?.origin?.type, .application)
+        let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "origin" : {
+    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "name" : "135CDABE-9343-7242-4233-1020384789AE",
+    "type" : "application"
+  },
+  "payload" : {
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 1,
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "subType" : "calibration",
+  "time" : "2020-01-02T03:00:23.000Z",
+  "type" : "deviceEvent",
+  "units" : "mg/dL",
+  "value" : 123
+}
+"""
+        )
     }
     
-    func testSMBG() {
-        let sample = StoredGlucoseSample(uuid: UUID(),
-                                         provenanceIdentifier: UUID().uuidString,
-                                         syncIdentifier: UUID().uuidString,
+    func testDatumSMBG() {
+        let sample = StoredGlucoseSample(uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                         provenanceIdentifier: "135CDABE-9343-7242-4233-1020384789AE",
+                                         syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
                                          syncVersion: 2,
-                                         startDate: Date(),
+                                         startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
                                          quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 167),
                                          condition: nil,
                                          trend: nil,
@@ -54,26 +65,36 @@ class StoredGlucoseSampleTests: XCTestCase {
                                          wasUserEntered: true,
                                          device: nil,
                                          healthKitEligibleDate: nil)
-        let datum = sample.datum as? TidepoolKit.TSMBGDatum
-        XCTAssertNotNil(datum)
-        XCTAssertEqual(datum?.time, sample.startDate)
-        XCTAssertEqual(datum?.value, 167)
-        XCTAssertEqual(datum?.units, .milligramsPerDeciliter)
-        XCTAssertEqual(datum?.subType, .manual)
-        XCTAssertNil(datum?.annotations)
-        XCTAssertNotNil(datum?.origin)
-        XCTAssertEqual(datum?.origin?.id, sample.syncIdentifier)
-        XCTAssertEqual(datum?.origin?.name, sample.provenanceIdentifier)
-        XCTAssertNil(datum?.origin?.version)
-        XCTAssertEqual(datum?.origin?.type, .application)
+        let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "origin" : {
+    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "name" : "135CDABE-9343-7242-4233-1020384789AE",
+    "type" : "application"
+  },
+  "payload" : {
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 2,
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "subType" : "manual",
+  "time" : "2020-01-02T03:00:23.000Z",
+  "type" : "smbg",
+  "units" : "mg/dL",
+  "value" : 167
+}
+"""
+        )
     }
     
-    func testCBGNormal() {
-        let sample = StoredGlucoseSample(uuid: UUID(),
-                                         provenanceIdentifier: UUID().uuidString,
-                                         syncIdentifier: UUID().uuidString,
+    func testDatumCBGNormal() {
+        let sample = StoredGlucoseSample(uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                         provenanceIdentifier: "135CDABE-9343-7242-4233-1020384789AE",
+                                         syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
                                          syncVersion: 3,
-                                         startDate: Date(),
+                                         startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
                                          quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 123),
                                          condition: nil,
                                          trend: .flat,
@@ -82,27 +103,37 @@ class StoredGlucoseSampleTests: XCTestCase {
                                          wasUserEntered: false,
                                          device: nil,
                                          healthKitEligibleDate: nil)
-        let datum = sample.datum as? TidepoolKit.TCBGDatum
-        XCTAssertNotNil(datum)
-        XCTAssertEqual(datum?.time, sample.startDate)
-        XCTAssertEqual(datum?.value, 123)
-        XCTAssertEqual(datum?.units, .milligramsPerDeciliter)
-        XCTAssertEqual(datum?.trend, .constant)
-        XCTAssertEqual(datum?.trendRate, 0.1)
-        XCTAssertNil(datum?.annotations)
-        XCTAssertNotNil(datum?.origin)
-        XCTAssertEqual(datum?.origin?.id, sample.syncIdentifier)
-        XCTAssertEqual(datum?.origin?.name, sample.provenanceIdentifier)
-        XCTAssertNil(datum?.origin?.version)
-        XCTAssertEqual(datum?.origin?.type, .application)
+        let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "origin" : {
+    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "name" : "135CDABE-9343-7242-4233-1020384789AE",
+    "type" : "application"
+  },
+  "payload" : {
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 3,
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "time" : "2020-01-02T03:00:23.000Z",
+  "trend" : "constant",
+  "trendRate" : 0.10000000000000001,
+  "type" : "cbg",
+  "units" : "mg/dL",
+  "value" : 123
+}
+"""
+        )
     }
     
-    func testCBGBelowRange() {
-        let sample = StoredGlucoseSample(uuid: UUID(),
-                                         provenanceIdentifier: UUID().uuidString,
-                                         syncIdentifier: UUID().uuidString,
+    func testDatumCBGBelowRange() {
+        let sample = StoredGlucoseSample(uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                         provenanceIdentifier: "135CDABE-9343-7242-4233-1020384789AE",
+                                         syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
                                          syncVersion: 4,
-                                         startDate: Date(),
+                                         startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
                                          quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40.0),
                                          condition: .belowRange,
                                          trend: .down,
@@ -111,31 +142,44 @@ class StoredGlucoseSampleTests: XCTestCase {
                                          wasUserEntered: false,
                                          device: nil,
                                          healthKitEligibleDate: nil)
-        let datum = sample.datum as? TidepoolKit.TCBGDatum
-        XCTAssertNotNil(datum)
-        XCTAssertEqual(datum?.time, sample.startDate)
-        XCTAssertEqual(datum?.value, 39.0)
-        XCTAssertEqual(datum?.units, .milligramsPerDeciliter)
-        XCTAssertEqual(datum?.trend, .slowFall)
-        XCTAssertEqual(datum?.trendRate, -1.0)
-        XCTAssertNotNil(datum?.annotations)
-        XCTAssertEqual(datum?.annotations?.count, 1)
-        XCTAssertEqual(datum?.annotations?[0]["code"] as? String, "bg/out-of-range")
-        XCTAssertEqual(datum?.annotations?[0]["value"] as? String, "low")
-        XCTAssertEqual(datum?.annotations?[0]["threshold"] as? Double, 40.0)
-        XCTAssertNotNil(datum?.origin)
-        XCTAssertEqual(datum?.origin?.id, sample.syncIdentifier)
-        XCTAssertEqual(datum?.origin?.name, sample.provenanceIdentifier)
-        XCTAssertNil(datum?.origin?.version)
-        XCTAssertEqual(datum?.origin?.type, .application)
+        let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "annotations" : [
+    {
+      "code" : "bg/out-of-range",
+      "threshold" : 40,
+      "value" : "low"
+    }
+  ],
+  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "origin" : {
+    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "name" : "135CDABE-9343-7242-4233-1020384789AE",
+    "type" : "application"
+  },
+  "payload" : {
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 4,
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "time" : "2020-01-02T03:00:23.000Z",
+  "trend" : "slowFall",
+  "trendRate" : -1,
+  "type" : "cbg",
+  "units" : "mg/dL",
+  "value" : 39
+}
+"""
+        )
     }
     
-    func testCBGAboveRange() {
-        let sample = StoredGlucoseSample(uuid: UUID(),
-                                         provenanceIdentifier: UUID().uuidString,
-                                         syncIdentifier: UUID().uuidString,
+    func testDatumCBGAboveRange() {
+        let sample = StoredGlucoseSample(uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                         provenanceIdentifier: "135CDABE-9343-7242-4233-1020384789AE",
+                                         syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
                                          syncVersion: 5,
-                                         startDate: Date(),
+                                         startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
                                          quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 400.0),
                                          condition: .aboveRange,
                                          trend: .upUp,
@@ -144,22 +188,43 @@ class StoredGlucoseSampleTests: XCTestCase {
                                          wasUserEntered: false,
                                          device: nil,
                                          healthKitEligibleDate: nil)
-        let datum = sample.datum as? TidepoolKit.TCBGDatum
-        XCTAssertNotNil(datum)
-        XCTAssertEqual(datum?.time, sample.startDate)
-        XCTAssertEqual(datum?.value, 401.0)
-        XCTAssertEqual(datum?.units, .milligramsPerDeciliter)
-        XCTAssertEqual(datum?.trend, .moderateRise)
-        XCTAssertEqual(datum?.trendRate, 4.0)
-        XCTAssertNotNil(datum?.annotations)
-        XCTAssertEqual(datum?.annotations?.count, 1)
-        XCTAssertEqual(datum?.annotations?[0]["code"] as? String, "bg/out-of-range")
-        XCTAssertEqual(datum?.annotations?[0]["value"] as? String, "high")
-        XCTAssertEqual(datum?.annotations?[0]["threshold"] as? Double, 400.0)
-        XCTAssertNotNil(datum?.origin)
-        XCTAssertEqual(datum?.origin?.id, sample.syncIdentifier)
-        XCTAssertEqual(datum?.origin?.name, sample.provenanceIdentifier)
-        XCTAssertNil(datum?.origin?.version)
-        XCTAssertEqual(datum?.origin?.type, .application)
+        let datum = sample.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "annotations" : [
+    {
+      "code" : "bg/out-of-range",
+      "threshold" : 400,
+      "value" : "high"
     }
+  ],
+  "id" : "A7C68902F9F396222674A76AD7A34A6D",
+  "origin" : {
+    "id" : "E71808A78873168E1C21DCD6636290BA",
+    "name" : "135CDABE-9343-7242-4233-1020384789AE",
+    "type" : "application"
+  },
+  "payload" : {
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 5,
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "time" : "2020-01-02T03:00:23.000Z",
+  "trend" : "moderateRise",
+  "trendRate" : 4,
+  "type" : "cbg",
+  "units" : "mg/dL",
+  "value" : 401
+}
+"""
+        )
+    }
+    
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder.tidepool
+        encoder.outputFormatting.insert(.prettyPrinted)
+        return encoder
+    }()
+    
+    private static let dateFormatter = ISO8601DateFormatter()
 }

--- a/TidepoolServiceKitTests/Extensions/SyncCarbObjectTests.swift
+++ b/TidepoolServiceKitTests/Extensions/SyncCarbObjectTests.swift
@@ -1,0 +1,73 @@
+//
+//  SyncCarbObjectTests.swift
+//  TidepoolServiceKitTests
+//
+//  Created by Darin Krauss on 10/29/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import HealthKit
+import TidepoolKit
+import LoopKit
+@testable import TidepoolServiceKit
+
+class SyncCarbObjectTests: XCTestCase {
+    func testDatumCalibrationDeviceEvent() {
+        let object = SyncCarbObject(absorptionTime: .hours(5),
+                                    createdByCurrentApp: true,
+                                    foodType: "Pizza",
+                                    grams: 45,
+                                    startDate: Self.dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
+                                    uuid: UUID(uuidString: "2A67A303-1234-4CB8-8263-79498265368E")!,
+                                    provenanceIdentifier: "com.loopkit.Loop",
+                                    syncIdentifier: "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+                                    syncVersion: 2,
+                                    userCreatedDate: Self.dateFormatter.date(from: "2020-01-02T03:01:23Z")!,
+                                    userUpdatedDate: Self.dateFormatter.date(from: "2020-01-02T03:05:23Z")!,
+                                    userDeletedDate: nil,
+                                    operation: .update,
+                                    addedDate: Self.dateFormatter.date(from: "2020-01-02T03:05:23Z")!,
+                                    supercededDate: nil)
+        let datum = object.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
+        XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
+{
+  "id" : "6BFD8643743DEA29867E79BED18E08BF",
+  "name" : "Pizza",
+  "nutrition" : {
+    "carbohydrate" : {
+      "net" : 45,
+      "units" : "grams"
+    },
+    "estimatedAbsorptionDuration" : 18000
+  },
+  "origin" : {
+    "id" : "72B3626CFE267489DF889FB597995437",
+    "name" : "com.loopkit.Loop",
+    "type" : "application"
+  },
+  "payload" : {
+    "addedDate" : "2020-01-02T03:05:23.000Z",
+    "syncIdentifier" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784",
+    "syncVersion" : 2,
+    "userCreatedDate" : "2020-01-02T03:01:23.000Z",
+    "userUpdatedDate" : "2020-01-02T03:05:23.000Z",
+    "uuid" : "2A67A303-1234-4CB8-8263-79498265368E"
+  },
+  "time" : "2020-01-02T03:00:23.000Z",
+  "type" : "food"
+}
+"""
+        )
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder.tidepool
+        encoder.outputFormatting.insert(.prettyPrinted)
+        return encoder
+    }()
+
+    private static let dateFormatter = ISO8601DateFormatter()
+}

--- a/TidepoolServiceKitTests/Extensions/SyncCarbObjectTests.swift
+++ b/TidepoolServiceKitTests/Extensions/SyncCarbObjectTests.swift
@@ -34,7 +34,7 @@ class SyncCarbObjectTests: XCTestCase {
         let datum = object.datum(for: "2B03D96C-6F5D-4140-99CD-80C3E64D6011")
         XCTAssertEqual(String(data: try! Self.encoder.encode(datum), encoding: .utf8), """
 {
-  "id" : "6BFD8643743DEA29867E79BED18E08BF",
+  "id" : "6bcc86152b10e405e126714fb583b783",
   "name" : "Pizza",
   "nutrition" : {
     "carbohydrate" : {
@@ -44,7 +44,7 @@ class SyncCarbObjectTests: XCTestCase {
     "estimatedAbsorptionDuration" : 18000
   },
   "origin" : {
-    "id" : "72B3626CFE267489DF889FB597995437",
+    "id" : "72b3626cfe267489df889fb597995437",
     "name" : "com.loopkit.Loop",
     "type" : "application"
   },

--- a/TidepoolServiceKitTests/Private/Extensions/TimeInterval.swift
+++ b/TidepoolServiceKitTests/Private/Extensions/TimeInterval.swift
@@ -1,0 +1,117 @@
+//
+//  TimeInterval.swift
+//  TidepoolServiceKitTests
+//
+//  Created by Darin Krauss on 10/29/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+extension TimeInterval {
+    static let day = days(1)
+    static let hour = hours(1)
+    static let minute = minutes(1)
+    static let second = seconds(1)
+    static let millisecond = milliseconds(1)
+
+    static func days(_ days: Double) -> Self {
+        return Self(days: days)
+    }
+
+    static func days(_ days: Int) -> Self {
+        return Self(days: days)
+    }
+
+    static func hours(_ hours: Double) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func hours(_ hours: Int) -> Self {
+        return Self(hours: hours)
+    }
+
+    static func minutes(_ minutes: Double) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func minutes(_ minutes: Int) -> Self {
+        return Self(minutes: minutes)
+    }
+
+    static func seconds(_ seconds: Double) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func seconds(_ seconds: Int) -> Self {
+        return Self(seconds: seconds)
+    }
+
+    static func milliseconds(_ milliseconds: Double) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    static func milliseconds(_ milliseconds: Int) -> Self {
+        return Self(milliseconds: milliseconds)
+    }
+
+    init(days: Double) {
+        self.init(hours: days * 24)
+    }
+
+    init(days: Int) {
+        self.init(hours: days * 24)
+    }
+
+    init(hours: Double) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(hours: Int) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(minutes: Double) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(minutes: Int) {
+        self.init(seconds: minutes * 60)
+    }
+
+    init(seconds: Double) {
+        self.init(seconds)
+    }
+
+    init(seconds: Int) {
+        self.init(seconds)
+    }
+
+    init(milliseconds: Double) {
+        self.init(seconds: milliseconds / 1000)
+    }
+
+    init(milliseconds: Int) {
+        self.init(seconds: Double(milliseconds) / 1000)
+    }
+
+    var days: Double {
+        return hours / 24
+    }
+
+    var hours: Double {
+        return minutes / 60
+    }
+
+    var minutes: Double {
+        return seconds / 60
+    }
+
+    var seconds: Double {
+        return self
+    }
+
+    var milliseconds: Double {
+        return seconds * 1000
+    }
+}


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3924
- Adorn carb and glucose data with unique id (to be used by reference in other data, i.e. dosing decisions)
- Incorporate user id when generating unique ids (to prevent namespace collisions)
- Hash ids and synthetic syncIdentifiers to provide consistent "id" features
- Document mapping of properties to Tidepool backend data model in code
- Add relevant non-Tidepool data model properties in payload
- Fix glucose out-of-range annotations to report expected value (Tidepool Loop stores last valid value while Tidepool backend data model expects first invalid value)
- Add device id field for glucose upload