### PR TITLE
LOOP-4665 Update test for api change

### DIFF
--- a/TidepoolServiceKitTests/Extensions/StoredDosingDecisionTests.swift
+++ b/TidepoolServiceKitTests/Extensions/StoredDosingDecisionTests.swift
@@ -354,7 +354,6 @@ fileprivate extension StoredDosingDecision {
                                                               duration: .minutes(30))
         let automaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: tempBasalRecommendation, bolusUnits: 1.25)
         let manualBolusRecommendation = ManualBolusRecommendationWithDate(recommendation: ManualBolusRecommendation(amount: 1.2,
-                                                                                                                    pendingInsulin: 0.75,
                                                                                                                     notice: .predictedGlucoseBelowTarget(minGlucose: PredictedGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T23:03:15Z")!,
                                                                                                                                                                                            quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 75.5)))),
                                                                           date: dateFormatter.date(from: "2020-05-14T22:38:16Z")!)


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4665

ManualBolusRecommendation no longer has a `pendingInsulin` field.