### PR TITLE
Manual dose upload

### DIFF
--- a/TidepoolService.xcodeproj/project.pbxproj
+++ b/TidepoolService.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/TidepoolServiceKit/Extensions/DoseEntry.swift
+++ b/TidepoolServiceKit/Extensions/DoseEntry.swift
@@ -96,11 +96,11 @@ extension DoseEntry: IdentifiableDatum {
     }
 
     private func dataForBolus(for userId: String, hostIdentifier: String, hostVersion: String) -> [TDatum] {
-        if manuallyEntered {
-            return dataForBolusManuallyEntered(for: userId, hostIdentifier: hostIdentifier, hostVersion: hostVersion)
-
-            
-        } else if automatic != true {
+        // TODO: revert to using .insulin datum type once fully supported in Tidepool frontend
+//        if manuallyEntered {
+//            return dataForBolusManuallyEntered(for: userId, hostIdentifier: hostIdentifier, hostVersion: hostVersion)
+//        } else 
+        if automatic != true {
             return dataForBolusManual(for: userId, hostIdentifier: hostIdentifier, hostVersion: hostVersion)
         }  else {
             return dataForBolusAutomatic(for: userId, hostIdentifier: hostIdentifier, hostVersion: hostVersion)
@@ -134,6 +134,11 @@ extension DoseEntry: IdentifiableDatum {
                                       normal: !isMutable ? deliveredUnits : programmedUnits,
                                       expectedNormal: !isMutable && programmedUnits != deliveredUnits ? programmedUnits : nil,
                                       insulinFormulation: datumInsulinFormulation)
+
+        if manuallyEntered {
+            datum.notes = ["manual entry"]
+        }
+
         let origin = datumOrigin(for: resolvedIdentifier(for: TNormalBolusDatum.self), hostIdentifier: hostIdentifier, hostVersion: hostVersion)
         datum = datum.adornWith(id: datumId(for: userId, type: TNormalBolusDatum.self),
                                 annotations: datumAnnotations,

--- a/TidepoolServiceKit/de.lproj/Localizable.strings
+++ b/TidepoolServiceKit/de.lproj/Localizable.strings
@@ -1,6 +1,15 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Konfigurationsfehler";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "DataSet Id fehlt";
+
+/* Alert acknowledgment OK button */
+"OK" = "OK";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Tidepool Service-Autorisierung";
 

--- a/TidepoolServiceKit/it.lproj/Localizable.strings
+++ b/TidepoolServiceKit/it.lproj/Localizable.strings
@@ -1,6 +1,18 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Errore di configurazione";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "DataSet mancante";
+
+/* Alert acknowledgment OK button */
+"OK" = "OK";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Servizio d'autorizzazione Tidepool";
+
+/* The body text for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate." = "Il servizio Tidepool non è più autorizzato. Per favore vai nelle impostazioni di Tidepool e riautenticati.";
 

--- a/TidepoolServiceKit/nb.lproj/Localizable.strings
+++ b/TidepoolServiceKit/nb.lproj/Localizable.strings
@@ -1,6 +1,18 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Konfigurasjonsfeil";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "Mangler DataSet-ID";
+
+/* Alert acknowledgment OK button */
+"OK" = "Ok";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Autorisasjon av Tidepool-tjenesten";
+
+/* The body text for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate." = "Tidepool-tjenesten er ikke lenger autorisert. Gå til innstillingene for Tidepool-tjenesten og godkjenn på nytt.";
 

--- a/TidepoolServiceKit/nl.lproj/Localizable.strings
+++ b/TidepoolServiceKit/nl.lproj/Localizable.strings
@@ -1,6 +1,18 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Configuratiefout";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "Ontbrekende Gegevensset Id";
+
+/* Alert acknowledgment OK button */
+"OK" = "Ok";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Tidepool Service Autorisatie";
+
+/* The body text for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate." = "De Tidepool-service is niet langer geautoriseerd. Navigeer naar de instellingen van de Tidepool-service en voer opnieuw authenticatie uit.";
 

--- a/TidepoolServiceKit/pl.lproj/Localizable.strings
+++ b/TidepoolServiceKit/pl.lproj/Localizable.strings
@@ -1,6 +1,18 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Błąd konfiguracji";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "Brak identyfikatora zestawu danych";
+
+/* Alert acknowledgment OK button */
+"OK" = "OK";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Autoryzacja serwisu Tidepool";
+
+/* The body text for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate." = "Serwis Tidepool nie jest już autoryzowany. Przejdź do ustawień usługi Tidepool i ponownie się uwierzytelnij.";
 

--- a/TidepoolServiceKit/ru.lproj/Localizable.strings
+++ b/TidepoolServiceKit/ru.lproj/Localizable.strings
@@ -1,6 +1,18 @@
 /* Error string for TidepoolServiceError.configuration */
 "Configuration Error" = "Ошибка конфигурации";
 
+/* Error string for TidepoolServiceError.missingDataSetId */
+"Missing DataSet Id" = "Отсутствует идентификатор набора данных";
+
+/* Alert acknowledgment OK button */
+"OK" = "OK";
+
 /* The title of the Tidepool service */
 "Tidepool" = "Tidepool";
+
+/* The title for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool Service Authorization" = "Авторизация сервиса Tidepool";
+
+/* The body text for an alert generated when TidepoolService is no longer authorized. */
+"Tidepool service is no longer authorized. Please navigate to Tidepool Service settings and reauthenticate." = "Служба Tidepool больше не авторизована. Пожалуйста, перейдите к настройкам службы Tidepool и повторно авторизуйтесь.";
 

--- a/TidepoolServiceKitUI/de.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/de.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Bist Du sicher, dass Du diesen Dienst löschen möchtest?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Schließen";
+
 /* Button title to delete a service */
 "Delete Service" = "Dienst löschen";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Umgebung";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Angemeldet als";
+
+/* Tidepool login button title */
+"Login" = "Anmelden";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Token zurückziehen";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Du bist nicht angemeldet.";
 

--- a/TidepoolServiceKitUI/it.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/it.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Sei sicuro di voler eliminare questo servizio?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Chiuso";
+
 /* Button title to delete a service */
 "Delete Service" = "Elimina Servizio";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Ambiente";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Autenticato come";
+
+/* Tidepool login button title */
+"Login" = "Login";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Revoca il token";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Non sei autenticato.";
 

--- a/TidepoolServiceKitUI/nb.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/nb.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Er du sikker på at du vil slette denne tjenesten?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Lukk";
+
 /* Button title to delete a service */
 "Delete Service" = "Slett tjeneste";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Miljø";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Innlogget som";
+
+/* Tidepool login button title */
+"Login" = "Logg Inn";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Tilbakekall token";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Du er ikke innlogget.";
 

--- a/TidepoolServiceKitUI/nl.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/nl.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Weet je zeker dat je deze service wil verwijderen?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Sluiten";
+
 /* Button title to delete a service */
 "Delete Service" = "Service Verwijderen";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Omgeving";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Ingelogd als";
+
+/* Tidepool login button title */
+"Login" = "Inloggen";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Token intrekken";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Je bent niet ingelogd.";
 

--- a/TidepoolServiceKitUI/pl.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/pl.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Czy na pewno chcesz usunąć tę usługę?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Zamknij";
+
 /* Button title to delete a service */
 "Delete Service" = "Usuń usługę";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Środowisko";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Zalogowany jako";
+
+/* Tidepool login button title */
+"Login" = "Login";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Unieważnij token";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Nie jesteś zalogowany.";
 

--- a/TidepoolServiceKitUI/ru.lproj/Localizable.strings
+++ b/TidepoolServiceKitUI/ru.lproj/Localizable.strings
@@ -1,6 +1,25 @@
 /* Confirmation message for deleting a service */
 "Are you sure you want to delete this service?" = "Вы уверены, что хотите удалить этот сервис?";
 
+/* Close navigation button title of an onboarding section page view */
+"Close" = "Закрыть";
+
 /* Button title to delete a service */
 "Delete Service" = "Удалить сервис";
+
+/* Label title for displaying selected Tidepool server environment.
+   Tidepool login environment action sheet title */
+"Environment" = "Environment";
+
+/* LoginViewModel description text when logged in */
+"Logged in as" = "Вы вошли как";
+
+/* Tidepool login button title */
+"Login" = "Вход в систему";
+
+/* Button title to revoke oauth tokens */
+"Revoke token" = "Отозвать токен";
+
+/* LoginViewModel description text when not logged in */
+"You are not logged in." = "Вы не авторизованы.";
 


### PR DESCRIPTION
Uploads manual doses as normal doses. `.insulin` datum type appears to not be supported in the Tidepool frontend.  Until it is supported, we'll do this workaround.

Also includes some translations that were missed.