### PR TITLE
LOOP-4098 - Specify correct duration for basal segments

### DIFF
--- a/TidepoolServiceKit/Extensions/DoseEntry.swift
+++ b/TidepoolServiceKit/Extensions/DoseEntry.swift
@@ -82,8 +82,8 @@ extension DoseEntry: IdentifiableDatum {
         payload["deliveredUnits"] = datumBasalDeliveredUnits
 
         var datum = TAutomatedBasalDatum(time: datumTime,
-                                         duration: !isMutable ? datumDuration : 0,
-                                         expectedDuration: !isMutable && datumDuration < basalDatumExpectedDuration ? basalDatumExpectedDuration : nil,
+                                         duration: datumDuration,
+                                         expectedDuration: nil,
                                          rate: datumScheduledBasalRate,
                                          scheduleName: StoredSettings.activeScheduleNameDefault,
                                          insulinFormulation: datumInsulinFormulation)

--- a/TidepoolServiceKitTests/Extensions/DoseEntryTests.swift
+++ b/TidepoolServiceKitTests/Extensions/DoseEntryTests.swift
@@ -38,7 +38,6 @@ class DoseEntryDataTests: XCTestCase {
   {
     "deliveryType" : "automated",
     "duration" : 1500000,
-    "expectedDuration" : 1800000,
     "id" : "f839af02f6832d7c81d636dbbbadbc01",
     "insulinFormulation" : {
       "simple" : {


### PR DESCRIPTION
In-progress basal segments were getting set with no duration.