### PR TITLE
LOOP-5323 Abbreviation and preset name cannot be empty string

### DIFF
--- a/TidepoolService.xcodeproj/xcshareddata/xcschemes/Shared.xcscheme
+++ b/TidepoolService.xcodeproj/xcshareddata/xcschemes/Shared.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TidepoolServiceKit/Extensions/StoredSettings.swift
+++ b/TidepoolServiceKit/Extensions/StoredSettings.swift
@@ -365,7 +365,9 @@ fileprivate extension TemporaryPreset {
                                                  insulinSensitivityScaleFactor: settings.datumInsulinSensitivityScaleFactor)
     }
     
-    var datumAbbreviation: String? { symbol?.textualRepresentation }
+    var datumAbbreviation: String? {
+        symbol?.textualRepresentation?.isEmpty == true ? nil : symbol?.textualRepresentation
+    }
 
     var datumDuration: TimeInterval? { duration.isFinite ? duration.timeInterval : nil }
 }

--- a/TidepoolServiceKit/Extensions/TemporaryScheduleOverride.swift
+++ b/TidepoolServiceKit/Extensions/TemporaryScheduleOverride.swift
@@ -84,6 +84,10 @@ extension TemporaryScheduleOverride: IdentifiableDatum {
         guard case .preset(let preset) = context else {
             return nil
         }
+        guard preset.name.isEmpty == false else {
+            // This shouldn't happen, but the backend will reject the data if not set
+            return "unnamed"
+        }
         return preset.name
     }
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5323

The empty abbreviation error popped up again, and I also noticed new case where a preset with an empty string as a name was failing. This fixes both those cases.